### PR TITLE
Move capnp install steps in package.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN \
 # Copy support files across
 COPY root /
 
-# Install any required NPM modules
+# Install any required NPM modules (unsafe-perm: to allow for cloning)
 RUN cd /usr/bin/redsift && \
   npm install && \
   npm test && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ COPY root /
 
 # Install any required NPM modules (unsafe-perm: to allow for cloning)
 RUN cd /usr/bin/redsift && \
-  npm install && \
+  npm install --unsafe-perm && \ 
   npm test && \
   npm run es6 && rm -Rf node_modules/\@babel/* node_modules/jshint
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,12 +40,10 @@ RUN \
 # Copy support files across
 COPY root /
 
-# Build node-capnp
-RUN /usr/bin/install_capnp
-
 # Install any required NPM modules
 RUN cd /usr/bin/redsift && \
   npm install && \
+  npm test && \
   npm run es6 && rm -Rf node_modules/\@babel/* node_modules/jshint
 
 

--- a/root/usr/bin/redsift/install_capnp
+++ b/root/usr/bin/redsift/install_capnp
@@ -1,19 +1,17 @@
 #!/bin/bash
 set -eu
 
-cd /usr/bin/redsift
+nv="${NODE_VERSION:-12.14.0}"
 
-echo $NODE_VERSION
+echo "Installing node-capnp for node:${nv}..."
 
-if [[ $NODE_VERSION == 8* ]]; then
+rm -rf ./node-capnp
+if [[ $nv == 8* ]]; then
     git clone https://github.com/capnproto/node-capnp.git
-elif [[ $NODE_VERSION == 12* ]]; then
+elif [[ $nv == 12* ]]; then
     git clone --single-branch --branch node12 https://github.com/redsift/node-capnp.git
 else
     git clone --single-branch --branch patched https://github.com/redsift/node-capnp.git
 fi
 
-cd node-capnp
-git status
-npm run install
-npm run test
+npm i --prefix ./node-capnp

--- a/root/usr/bin/redsift/install_capnp
+++ b/root/usr/bin/redsift/install_capnp
@@ -14,4 +14,3 @@ else
     git clone --single-branch --branch patched https://github.com/redsift/node-capnp.git
 fi
 
-npm i --prefix ./node-capnp

--- a/root/usr/bin/redsift/package.json
+++ b/root/usr/bin/redsift/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "description": "Sets up the sandbox for NodeJS backend tasks",
   "scripts": {
-    "preinstall": "./install_capnp",
+    "preinstall": "./install_capnp && npm i --prefix ./node-capnp",
     "lint": "jshint --config .jshinrc run-es6.js",
     "es5": "node node_modules/babel-cli/bin/babel.js run-es6.js -o run.js",
     "es6": "cp run-es6.js run.js",

--- a/root/usr/bin/redsift/package.json
+++ b/root/usr/bin/redsift/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "description": "Sets up the sandbox for NodeJS backend tasks",
   "scripts": {
-    "prepare": "./install_capnp",
+    "preinstall": "./install_capnp",
     "lint": "jshint --config .jshinrc run-es6.js",
     "es5": "node node_modules/babel-cli/bin/babel.js run-es6.js -o run.js",
     "es6": "cp run-es6.js run.js",

--- a/root/usr/bin/redsift/package.json
+++ b/root/usr/bin/redsift/package.json
@@ -3,9 +3,11 @@
   "version": "1.1.0",
   "description": "Sets up the sandbox for NodeJS backend tasks",
   "scripts": {
+    "prepare": "./install_capnp",
     "lint": "jshint --config .jshinrc run-es6.js",
     "es5": "node node_modules/babel-cli/bin/babel.js run-es6.js -o run.js",
-    "es6": "cp run-es6.js run.js"
+    "es6": "cp run-es6.js run.js",
+    "test": "npm test --prefix ./node-capnp"
   },
   "dependencies": {
     "nanomsg": "^4.1.0",


### PR DESCRIPTION
This allows for a simple installation flow when it's used as a submodule (e.g. grip + SDK)
The only drawback is the usage of the `--unsafe-perm` flag inside the Dockerfile.