### PR TITLE
Fix loading schema2 payloads for non-RPC requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jest": "26.0.1",
     "jest-cli": "26.0.1",
     "jest-junit": "10.0.0",
-    "nanomsg": "4.1.0",
+    "nanomsg": "^4.1.0",
     "uuid": "8.1.0"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jest": "26.0.1",
     "jest-cli": "26.0.1",
     "jest-junit": "10.0.0",
-    "nanomsg": "^4.1.0",
+    "nanomsg": "4.1.0",
     "uuid": "8.1.0"
   },
   "jest": {

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  singleQuote: true,
+  trailingComma: 'es5',
+};

--- a/root/usr/bin/redsift/convert.js
+++ b/root/usr/bin/redsift/convert.js
@@ -35,9 +35,9 @@ const encodeCapnProto = (d) => {
 }
 
 module.exports = {
-  rpcSchema: rpcSchema,
-  b64Decode: b64Decode,
-  b64Encode: b64Encode,
-  decodeCapnProto: decodeCapnProto,
-  encodeCapnProto: encodeCapnProto
+  rpcSchema,
+  b64Decode,
+  b64Encode,
+  decodeCapnProto,
+  encodeCapnProto,
 };

--- a/root/usr/bin/redsift/init.js
+++ b/root/usr/bin/redsift/init.js
@@ -46,10 +46,10 @@ if ((sift.dag === undefined) || (sift.dag.nodes === undefined)) {
 }
 
 module.exports = {
-  nodes: nodes,
-  SIFT_ROOT: SIFT_ROOT,
-  SIFT_JSON: SIFT_JSON,
-  IPC_ROOT: IPC_ROOT,
-  DRY: DRY,
-  sift: sift
+  nodes,
+  SIFT_ROOT,
+  SIFT_JSON,
+  IPC_ROOT,
+  DRY,
+  sift,
 };

--- a/root/usr/bin/redsift/install.js
+++ b/root/usr/bin/redsift/install.js
@@ -82,5 +82,5 @@ final.then(function () {
 });
 
 module.exports = {
-  final
+  final,
 }

--- a/root/usr/bin/redsift/protocol.js
+++ b/root/usr/bin/redsift/protocol.js
@@ -45,16 +45,18 @@ function fromEncodedMessageFile(body) {
   ['in', 'with'].forEach(function (k) {
     if (k in body) {
       body[k].data.forEach(d => {
-        const fileContent = readFileContent(d.value);
-        d.value = convert.b64Decode(fileContent);
+        const fileName = Buffer.from(d.value, 'base64').toString();
+        const fileContent = readFileContent(fileName);
+        d.value = fileContent;
       });
     }
   });
 
   if ('get' in body) {
     body.get.forEach(function (g) {
-      const fileContent = readFileContent(g.value);
-      g = convert.b64Decode(fileContent);
+      const fileName = Buffer.from(g.value, 'base64').toString();
+      const fileContent = readFileContent(fileName);
+      g = fileContent;
     });
   }
 

--- a/root/usr/bin/redsift/protocol.js
+++ b/root/usr/bin/redsift/protocol.js
@@ -126,4 +126,5 @@ module.exports = {
   fromEncodedMessage,
   toEncodedCapnpMessage,
   toEncodedMessage,
+  flattenNestedArrays,
 };

--- a/root/usr/bin/redsift/protocol.js
+++ b/root/usr/bin/redsift/protocol.js
@@ -4,11 +4,6 @@ const convert = require('./convert.js');
 const fs = require('fs');
 const path = require('path');
 
-const readFileContent = (file) => {
-  const filename = path.join(process.env.IPC_ROOT, file);
-  return fs.readFileSync(filename);
-};
-
 function flattenNestedArrays(value) {
   if (Array.isArray(value)) {
     if (value.length === 1 && Array.isArray(value[0])) {
@@ -20,8 +15,9 @@ function flattenNestedArrays(value) {
 }
 
 function getFileContent(d) {
-  const fileName = Buffer.from(d.value, 'base64').toString();
-  return readFileContent(fileName);
+  return fs.readFileSync(
+    path.join(process.env.IPC_ROOT, Buffer.from(d.value, 'base64').toString())
+  );
 }
 
 function fromEncodedCapnpMessage(body) {

--- a/root/usr/bin/redsift/protocol.js
+++ b/root/usr/bin/redsift/protocol.js
@@ -19,22 +19,25 @@ function flattenNestedArrays(value) {
   return [value];
 }
 
+function getFileContent(d) {
+  const fileName = Buffer.from(d.value, 'base64').toString();
+  return readFileContent(fileName);
+}
+
 function fromEncodedCapnpMessage(body) {
   ['in', 'with'].forEach(function (k) {
     if (k in body) {
       body[k].data.forEach(d => {
-        const fileName = Buffer.from(d.value, 'base64').toString();
-        const fileContent = readFileContent(fileName);
-        d.value = convert.decodeCapnProto(fileContent);
+        d.value = convert.decodeCapnProto(getFileContent(d));
       });
     }
   });
 
   if ('get' in body) {
     body.get.forEach(function (g) {
-      const fileName = Buffer.from(g.value, 'base64').toString();
-      const fileContent = readFileContent(fileName);
-      g = convert.decodeCapnProto(fileContent);
+      g.data.forEach(d => {
+        d.value = convert.decodeCapnProto(getFileContent(d));
+      });
     });
   }
 
@@ -45,18 +48,16 @@ function fromEncodedMessageFile(body) {
   ['in', 'with'].forEach(function (k) {
     if (k in body) {
       body[k].data.forEach(d => {
-        const fileName = Buffer.from(d.value, 'base64').toString();
-        const fileContent = readFileContent(fileName);
-        d.value = fileContent;
+        d.value = getFileContent(d);
       });
     }
   });
 
   if ('get' in body) {
     body.get.forEach(function (g) {
-      const fileName = Buffer.from(g.value, 'base64').toString();
-      const fileContent = readFileContent(fileName);
-      g = fileContent;
+      g.data.forEach(d => {
+        d.value = getFileContent(d);
+      });
     });
   }
 

--- a/root/usr/bin/redsift/protocol.js
+++ b/root/usr/bin/redsift/protocol.js
@@ -5,9 +5,9 @@ const fs = require('fs');
 const path = require('path');
 
 const readFileContent = (file) => {
-  const filename = path.join(process.env.IPC_ROOT, file)
+  const filename = path.join(process.env.IPC_ROOT, file);
   return fs.readFileSync(filename);
-}
+};
 
 function flattenNestedArrays(value) {
   if (Array.isArray(value)) {
@@ -27,16 +27,21 @@ function getFileContent(d) {
 function fromEncodedCapnpMessage(body) {
   ['in', 'with'].forEach(function (k) {
     if (k in body) {
-      body[k].data.forEach(d => {
-        d.value = convert.decodeCapnProto(getFileContent(d));
+      body[k].data.forEach((d) => {
+        const fc = getFileContent(d);
+        if (k === 'in') {
+          d.value = convert.decodeCapnProto(fc);
+        } else {
+          d.value = fc;
+        }
       });
     }
   });
 
   if ('get' in body) {
     body.get.forEach(function (g) {
-      g.data.forEach(d => {
-        d.value = convert.decodeCapnProto(getFileContent(d));
+      g.data.forEach((d) => {
+        d.value = getFileContent(d);
       });
     });
   }
@@ -47,7 +52,7 @@ function fromEncodedCapnpMessage(body) {
 function fromEncodedMessageFile(body) {
   ['in', 'with'].forEach(function (k) {
     if (k in body) {
-      body[k].data.forEach(d => {
+      body[k].data.forEach((d) => {
         d.value = getFileContent(d);
       });
     }
@@ -55,7 +60,7 @@ function fromEncodedMessageFile(body) {
 
   if ('get' in body) {
     body.get.forEach(function (g) {
-      g.data.forEach(d => {
+      g.data.forEach((d) => {
         d.value = getFileContent(d);
       });
     });
@@ -88,7 +93,15 @@ function toEncodedCapnpMessage(value, diff, decodeTime, nodeTime) {
     i.value = convert.encodeCapnProto(i.value).toString('base64');
   });
   const encodeTime = process.hrtime(startEncode);
-  return JSON.stringify({ out: flat, stats: { result: diff, decode: decodeTime, node: nodeTime, encode: encodeTime } });
+  return JSON.stringify({
+    out: flat,
+    stats: {
+      result: diff,
+      decode: decodeTime,
+      node: nodeTime,
+      encode: encodeTime,
+    },
+  });
 }
 
 function toEncodedMessage(value, diff, decodeTime, nodeTime) {
@@ -100,13 +113,21 @@ function toEncodedMessage(value, diff, decodeTime, nodeTime) {
     i = convert.b64Encode(i);
   });
   const encodeTime = process.hrtime(startEncode);
-  return JSON.stringify({ out: flat, stats: { result: diff, decode: decodeTime, node: nodeTime, encode: encodeTime } });
+  return JSON.stringify({
+    out: flat,
+    stats: {
+      result: diff,
+      decode: decodeTime,
+      node: nodeTime,
+      encode: encodeTime,
+    },
+  });
 }
 
 module.exports = {
-  fromEncodedCapnpMessage: fromEncodedCapnpMessage,
-  fromEncodedMessageFile: fromEncodedMessageFile,
-  fromEncodedMessage: fromEncodedMessage,
-  toEncodedCapnpMessage: toEncodedCapnpMessage,
-  toEncodedMessage: toEncodedMessage
+  fromEncodedCapnpMessage,
+  fromEncodedMessageFile,
+  fromEncodedMessage,
+  toEncodedCapnpMessage,
+  toEncodedMessage,
 };

--- a/root/usr/bin/redsift/run-es6.js
+++ b/root/usr/bin/redsift/run-es6.js
@@ -104,9 +104,9 @@ nodes.forEach(function (i) {
     const isApiRpc = detectNodeRpcOutput(nodeOutputs, rpcBucketNames);
     const isCapnProto = detectCapnProtocol(req);
 
-    if (isSchema2 && isApiRpc) {
+    if (isSchema2) {
       //console.debug(`Schema version 2 and _rpc output detected for bucket: ${req.in.bucket}`);
-      if (isCapnProto) {
+      if (isCapnProto && isApiRpc) {
         //console.debug(`Cap'n Proto Schema detected for bucket: ${req.in.bucket}`);
         req = protocol.fromEncodedCapnpMessage(req);
       } else {

--- a/root/usr/bin/redsift/run-es6.js
+++ b/root/usr/bin/redsift/run-es6.js
@@ -102,11 +102,11 @@ nodes.forEach(function (i) {
 
     const nodeOutputs = findBucketNodes(req.in.bucket);
     const isApiRpcOutput = detectNodeRpcOutput(nodeOutputs, rpcBucketNames);
-    const isCapnProto = detectCapnProtocol(req);
+    const isCapnProtoInput = detectCapnProtocol(req);
 
     if (isSchema2) {
       //console.debug(`Schema version 2 and _rpc output detected for bucket: ${req.in.bucket}`);
-      if (isCapnProto) {
+      if (isCapnProtoInput) {
         //console.debug(`Cap'n Proto Schema detected for bucket: ${req.in.bucket}`);
         req = protocol.fromEncodedCapnpMessage(req);
       } else {
@@ -148,7 +148,7 @@ nodes.forEach(function (i) {
         //console.log('REP-VALUE:', value);
         const nodeTime = process.hrtime(startNode);
         const diff = process.hrtime(start);
-        if (isApiRpcOutput && isCapnProto) {
+        if (isSchema2 && isApiRpcOutput) {
           reply.send(protocol.toEncodedCapnpMessage(value, diff, decodeTime, nodeTime));
         } else {
           reply.send(protocol.toEncodedMessage(value, diff, decodeTime, nodeTime));

--- a/root/usr/bin/redsift/run-es6.js
+++ b/root/usr/bin/redsift/run-es6.js
@@ -101,12 +101,12 @@ nodes.forEach(function (i) {
     let req = JSON.parse(msg);
 
     const nodeOutputs = findBucketNodes(req.in.bucket);
-    const isApiRpc = detectNodeRpcOutput(nodeOutputs, rpcBucketNames);
+    const isApiRpcOutput = detectNodeRpcOutput(nodeOutputs, rpcBucketNames);
     const isCapnProto = detectCapnProtocol(req);
 
     if (isSchema2) {
       //console.debug(`Schema version 2 and _rpc output detected for bucket: ${req.in.bucket}`);
-      if (isCapnProto && isApiRpc) {
+      if (isCapnProto) {
         //console.debug(`Cap'n Proto Schema detected for bucket: ${req.in.bucket}`);
         req = protocol.fromEncodedCapnpMessage(req);
       } else {
@@ -148,7 +148,7 @@ nodes.forEach(function (i) {
         //console.log('REP-VALUE:', value);
         const nodeTime = process.hrtime(startNode);
         const diff = process.hrtime(start);
-        if (isApiRpc && isCapnProto) {
+        if (isApiRpcOutput && isCapnProto) {
           reply.send(protocol.toEncodedCapnpMessage(value, diff, decodeTime, nodeTime));
         } else {
           reply.send(protocol.toEncodedMessage(value, diff, decodeTime, nodeTime));

--- a/test/javascript/protocol.test.js
+++ b/test/javascript/protocol.test.js
@@ -79,6 +79,17 @@ describe('protocol', () => {
     };
   };
 
+  describe('flattenNestedArrays func', () => {
+    test('nested array', () => {
+      const result = protocol.flattenNestedArrays([['a']]);
+      expect(result).toEqual(['a']);
+    });
+    test('no array', () => {
+      const result = protocol.flattenNestedArrays('a');
+      expect(result).toEqual(['a']);
+    });
+  });
+
   describe('fromEncodedCapnpMessage func', () => {
     test('in', () => {
       const KERASH_KEY = 'rstid:kerash:01DKYADEK8YVR3Y8011BVW5Z0T';
@@ -198,14 +209,18 @@ describe('protocol', () => {
     test('in', () => {
       const res = protocol.fromEncodedMessage(inReq());
       res.in.data.map((d) => {
-        expect(d.value.toString()).toEqual(Buffer.from(fileName, 'base64').toString());
+        expect(d.value.toString()).toEqual(
+          Buffer.from(fileName, 'base64').toString()
+        );
       });
     });
 
     test('with', () => {
       const res = protocol.fromEncodedMessage(withReq());
       res.with.data.map((d) => {
-        expect(d.value.toString()).toEqual(Buffer.from(fileName, 'base64').toString());
+        expect(d.value.toString()).toEqual(
+          Buffer.from(fileName, 'base64').toString()
+        );
       });
     });
 
@@ -213,7 +228,9 @@ describe('protocol', () => {
       const res = protocol.fromEncodedMessage(getReq());
       res.get.map((g) => {
         g.data.map((d) => {
-          expect(d.value.toString()).toEqual(Buffer.from(fileName, 'base64').toString());
+          expect(d.value.toString()).toEqual(
+            Buffer.from(fileName, 'base64').toString()
+          );
         });
       });
     });

--- a/test/javascript/run-es6.test.js
+++ b/test/javascript/run-es6.test.js
@@ -78,23 +78,13 @@ describe('run es6', () => {
     });
   });
 
-  describe('findBucketNodes', () => {
-    const run = require('../../root/usr/bin/redsift/run-es6.js');
-    test('get node config from req.in.bucket', () => {
-      const bucketName = 'api_scan';
-      const outputs = [{ "api_rpc": {} }]; // this is from the outputs in sift-schema2.json
-      const result = run.findBucketNodes(bucketName);
-      expect(result).toEqual(outputs);
-    })
-  });
-
   describe('getRpcBucketNamesFromSift', () => {
     // Setting schema version 2
     process.env.SIFT_JSON = 'sift-schema2.json';
     const run = require('../../root/usr/bin/redsift/run-es6.js');
     test('get _rpc exports from sift json', () => {
       const rpcExportBuckets = run.getRpcBucketNamesFromSift();
-      expect(rpcExportBuckets).toEqual(['api_rpc']);
+      expect(rpcExportBuckets).toEqual({"api_rpc": true});
     });
   });
 
@@ -104,19 +94,18 @@ describe('run es6', () => {
     const run = require('../../root/usr/bin/redsift/run-es6.js');
     test('get _rpc exports from sift json', () => {
       const rpcExportBuckets = run.getRpcBucketNamesFromSift();
-      expect(rpcExportBuckets).toEqual(['api_rpc']);
+      expect(rpcExportBuckets).toEqual({"api_rpc": true});
     });
   });
 
   describe('detectNodeRpcOutput', () => {
+    const init = require('../../root/usr/bin/redsift/init.js');
     // Setting schema version 2
     process.env.SIFT_JSON = 'sift-schema2.json';
     const run = require('../../root/usr/bin/redsift/run-es6.js');
     test('detect isApiRpcOutput', () => {
-      const bucketName = 'api_scan';
-      const nodeOutputs = run.findBucketNodes(bucketName);
       const rpcBucketNames = run.getRpcBucketNamesFromSift();
-      const isApiRpcOutput = run.detectNodeRpcOutput(nodeOutputs, rpcBucketNames);
+      const isApiRpcOutput = run.detectNodeRpcOutput(init.sift.dag.nodes[0].outputs, rpcBucketNames);
       expect(isApiRpcOutput).toEqual(true);
     });
   });

--- a/test/javascript/run-es6.test.js
+++ b/test/javascript/run-es6.test.js
@@ -112,12 +112,12 @@ describe('run es6', () => {
     // Setting schema version 2
     process.env.SIFT_JSON = 'sift-schema2.json';
     const run = require('../../root/usr/bin/redsift/run-es6.js');
-    test('detect isApiRpc', () => {
+    test('detect isApiRpcOutput', () => {
       const bucketName = 'api_scan';
       const nodeOutputs = run.findBucketNodes(bucketName);
       const rpcBucketNames = run.getRpcBucketNamesFromSift();
-      const isApiRpc = run.detectNodeRpcOutput(nodeOutputs, rpcBucketNames);
-      expect(isApiRpc).toEqual(true);
+      const isApiRpcOutput = run.detectNodeRpcOutput(nodeOutputs, rpcBucketNames);
+      expect(isApiRpcOutput).toEqual(true);
     });
   });
 });

--- a/test/javascript/run-es6.test.js
+++ b/test/javascript/run-es6.test.js
@@ -1,5 +1,15 @@
-describe('run es6', () => {
+const Nano = require('nanomsg');
+const protocol = require('../../root/usr/bin/redsift/protocol.js');
 
+jest.mock('../../root/usr/bin/redsift/protocol.js', () => ({
+  fromEncodedCapnpMessage: jest.fn(),
+  fromEncodedMessageFile: jest.fn(),
+  fromEncodedMessage: jest.fn(),
+  toEncodedCapnpMessage: jest.fn(),
+  toEncodedMessage: jest.fn(),
+}));
+
+describe('run es6', () => {
   beforeEach(() => {
     jest.resetModules();
   });
@@ -13,9 +23,183 @@ describe('run es6', () => {
     }
   });
 
+  test('Main: isSchema2: true, isCapnProtoInput: true', () => {
+    process.env.DRY = false;
+    process.env.SIFT_JSON = 'sift-schema2.json';
+    jest.mock('nanomsg', () => ({
+      socket: jest.fn(() => {
+        return {
+          rcvmaxsize: jest.fn(),
+          connect: jest.fn(),
+          on: jest.fn((method, cb) => {
+            const KERASH_KEY = 'rstid:kerash:01DKYADEK8YVR3Y8011BVW5Z0T';
+            const req = {
+              in: {
+                bucket: 'api',
+                data: [
+                  {
+                    name: 'api_rpc',
+                    key: KERASH_KEY,
+                    value: 'ZmlsZW5hbWU=',
+                    epoch: 0,
+                    generation: 0,
+                  },
+                ],
+              },
+            };
+            cb(JSON.stringify(req));
+          }),
+          send: jest.fn(),
+        };
+      }),
+    }));
+
+    const KERASH_KEY = 'rstid:kerash:01DKYADEK8YVR3Y8011BVW5Z0T';
+    protocol.fromEncodedCapnpMessage.mockReturnValue({
+      in: {
+        bucket: 'api',
+        data: [
+          {
+            name: 'api_rpc',
+            key: KERASH_KEY,
+            value: 'ZmlsZW5hbWU=',
+            epoch: 0,
+            generation: 0,
+          },
+        ],
+      },
+    });
+    protocol.toEncodedCapnpMessage.mockReturnValue({
+      a: 'b',
+    });
+
+    try {
+      require('../../root/usr/bin/redsift/run-es6.js');
+    } catch (e) {
+      console.log(e);
+      expect(true).toEqual(false);
+    }
+  });
+
+  test('Main: isSchema2: true, isCapnProtoInput: false', () => {
+    process.env.DRY = false;
+    process.env.SIFT_JSON = 'sift-schema2.json';
+    jest.mock('nanomsg', () => ({
+      socket: jest.fn(() => {
+        return {
+          rcvmaxsize: jest.fn(),
+          connect: jest.fn(),
+          on: jest.fn((method, cb) => {
+            const KEY = '01DKYADEK8YVR3Y8011BVW5Z0T';
+            const req = {
+              in: {
+                bucket: 'api',
+                data: [
+                  {
+                    name: 'api_rpc',
+                    key: KEY,
+                    value: 'ZmlsZW5hbWU=',
+                    epoch: 0,
+                    generation: 0,
+                  },
+                ],
+              },
+            };
+            cb(JSON.stringify(req));
+          }),
+          send: jest.fn(),
+        };
+      }),
+    }));
+
+    const KEY = '01DKYADEK8YVR3Y8011BVW5Z0T';
+    protocol.fromEncodedCapnpMessage.mockReturnValue({
+      in: {
+        bucket: 'api',
+        data: [
+          {
+            name: 'api_rpc',
+            key: KEY,
+            value: 'ZmlsZW5hbWU=',
+            epoch: 0,
+            generation: 0,
+          },
+        ],
+      },
+    });
+    protocol.toEncodedCapnpMessage.mockReturnValue({
+      a: 'b',
+    });
+
+    try {
+      require('../../root/usr/bin/redsift/run-es6.js');
+    } catch (e) {
+      console.log(e);
+      expect(true).toEqual(false);
+    }
+  });
+
+  test('Main: isSchema2: false, isCapnProtoInput: false', () => {
+    process.env.DRY = false;
+    process.env.SIFT_JSON = 'sift.json';
+    jest.mock('nanomsg', () => ({
+      socket: jest.fn(() => {
+        return {
+          rcvmaxsize: jest.fn(),
+          connect: jest.fn(),
+          on: jest.fn((method, cb) => {
+            const KEY = '01DKYADEK8YVR3Y8011BVW5Z0T';
+            const req = {
+              in: {
+                bucket: 'api',
+                data: [
+                  {
+                    name: 'api_rpc',
+                    key: KEY,
+                    value: 'ZmlsZW5hbWU=',
+                    epoch: 0,
+                    generation: 0,
+                  },
+                ],
+              },
+            };
+            cb(JSON.stringify(req));
+          }),
+          send: jest.fn(),
+        };
+      }),
+    }));
+
+    const KEY = '01DKYADEK8YVR3Y8011BVW5Z0T';
+    protocol.fromEncodedCapnpMessage.mockReturnValue({
+      in: {
+        bucket: 'api',
+        data: [
+          {
+            name: 'api_rpc',
+            key: KEY,
+            value: 'ZmlsZW5hbWU=',
+            epoch: 0,
+            generation: 0,
+          },
+        ],
+      },
+    });
+    protocol.toEncodedCapnpMessage.mockReturnValue({
+      a: 'b',
+    });
+
+    try {
+      require('../../root/usr/bin/redsift/run-es6.js');
+    } catch (e) {
+      console.log(e);
+      expect(true).toEqual(false);
+    }
+  });
+
   describe('dry run', () => {
     process.env.DRY = true;
-    jest.spyOn(global.console, 'log')
+    jest.spyOn(global.console, 'log');
     test('true', () => {
       require('../../root/usr/bin/redsift/run-es6.js');
       expect(console.log).toHaveBeenCalledWith('Detected Dry run');
@@ -30,13 +214,15 @@ describe('run es6', () => {
       const req = {
         in: {
           bucket: 'api_scan',
-          data: [{
-            key: 'rstid:kerash:01DMN8M07XAMSDFE5FXGK1WZY8',
-            value: 'aXBjZGF0YTM2NTE1OTEyNA==',
-            epoch: 1568376750,
-            generation: 0
-          }]
-        }
+          data: [
+            {
+              key: 'rstid:kerash:01DMN8M07XAMSDFE5FXGK1WZY8',
+              value: 'aXBjZGF0YTM2NTE1OTEyNA==',
+              epoch: 1568376750,
+              generation: 0,
+            },
+          ],
+        },
       };
       const result = run.detectCapnProtocol(req);
       expect(result).toEqual(true);
@@ -45,13 +231,15 @@ describe('run es6', () => {
       const req = {
         in: {
           bucket: 'api_scan',
-          data: [{
-            key: 'rstid:tada:01DMN8M07XAMSDFE5FXGK1WZY8',
-            value: 'aXBjZGF0YTM2NTE1OTEyNA==',
-            epoch: 1568376750,
-            generation: 0
-          }]
-        }
+          data: [
+            {
+              key: 'rstid:tada:01DMN8M07XAMSDFE5FXGK1WZY8',
+              value: 'aXBjZGF0YTM2NTE1OTEyNA==',
+              epoch: 1568376750,
+              generation: 0,
+            },
+          ],
+        },
       };
       const result = run.detectCapnProtocol(req);
       expect(result).toEqual(false);
@@ -59,11 +247,13 @@ describe('run es6', () => {
     test('console.log error', () => {
       const req = {
         in: {
-          data: [{
-            key: 'bananas',
-            bananas: 1234
-          }]
-        }
+          data: [
+            {
+              key: 'bananas',
+              bananas: 1234,
+            },
+          ],
+        },
       };
       const result = run.detectCapnProtocol(req);
       expect(result).toEqual(false);
@@ -71,7 +261,7 @@ describe('run es6', () => {
     });
     test('no req.in.data', () => {
       const req = {
-        in: {}
+        in: {},
       };
       const result = run.detectCapnProtocol(req);
       expect(result).toEqual(false);
@@ -84,7 +274,7 @@ describe('run es6', () => {
     const run = require('../../root/usr/bin/redsift/run-es6.js');
     test('get _rpc exports from sift json', () => {
       const rpcExportBuckets = run.getRpcBucketNamesFromSift();
-      expect(rpcExportBuckets).toEqual({"api_rpc": true});
+      expect(rpcExportBuckets).toEqual({ api_rpc: true });
     });
   });
 
@@ -94,7 +284,7 @@ describe('run es6', () => {
     const run = require('../../root/usr/bin/redsift/run-es6.js');
     test('get _rpc exports from sift json', () => {
       const rpcExportBuckets = run.getRpcBucketNamesFromSift();
-      expect(rpcExportBuckets).toEqual({"api_rpc": true});
+      expect(rpcExportBuckets).toEqual({ api_rpc: true });
     });
   });
 
@@ -105,7 +295,10 @@ describe('run es6', () => {
     const run = require('../../root/usr/bin/redsift/run-es6.js');
     test('detect isApiRpcOutput', () => {
       const rpcBucketNames = run.getRpcBucketNamesFromSift();
-      const isApiRpcOutput = run.detectNodeRpcOutput(init.sift.dag.nodes[0].outputs, rpcBucketNames);
+      const isApiRpcOutput = run.detectNodeRpcOutput(
+        init.sift.dag.nodes[0].outputs,
+        rpcBucketNames
+      );
       expect(isApiRpcOutput).toEqual(true);
     });
   });

--- a/test/server/node1.js
+++ b/test/server/node1.js
@@ -4,6 +4,8 @@ var fx = require('money');
 
 console.log('node1.js');
 
-module.exports = function(got) {
-	
-}
+module.exports = function (got) {
+  return {
+    a: 'b',
+  };
+};

--- a/test/sift-schema2.json
+++ b/test/sift-schema2.json
@@ -18,18 +18,27 @@
         "#": "Missing Node",
         "implementation": {
           "javascript": "node-missing.js"
+        },
+        "outputs": {
+          "api_rpc": {}
         }
       },
       {
         "#": "Test Node 2",
         "implementation": {
           "javascript": "server-alt/node2.js"
+        },
+        "outputs": {
+          "api_rpc": {}
         }
       },
       {
         "#": "Test Node 3",
         "implementation": {
           "javascript": "server-plain/node3.js"
+        },
+        "outputs": {
+          "api_rpc": {}
         }
       }
     ],

--- a/test/sift.json
+++ b/test/sift.json
@@ -1,30 +1,49 @@
 {
   "dag": {
-    "nodes":[
-		{
-			"#": "Test Node 1",
-			"implementation": {
-				"javascript": "server/node1.js"  
-			}
-		},
-		{
-			"#": "Missing Node",
-			"implementation": {
-				"javascript": "node-missing.js"  
-			}
-		},
-		{
-			"#": "Test Node 2",
-			"implementation": {
-				"javascript": "server-alt/node2.js"  
-			}
-		},
-		{
-			"#": "Test Node 3",
-			"implementation": {
-				"javascript": "server-plain/node3.js"
-			}
-		}			
-	]
+    "nodes": [
+      {
+        "#": "Test Node 1",
+        "implementation": {
+          "javascript": "server/node1.js"
+        },
+        "outputs": {
+          "api_rpc": {}
+        }
+      },
+      {
+        "#": "Missing Node",
+        "implementation": {
+          "javascript": "node-missing.js"
+        },
+        "outputs": {
+          "api_rpc": {}
+        }
+      },
+      {
+        "#": "Test Node 2",
+        "implementation": {
+          "javascript": "server-alt/node2.js"
+        },
+        "outputs": {
+          "api_rpc": {}
+        }
+      },
+      {
+        "#": "Test Node 3",
+        "implementation": {
+          "javascript": "server-plain/node3.js"
+        },
+        "outputs": {
+          "api_rpc": {}
+        }
+      }
+    ],
+    "outputs": {
+      "exports": {
+        "api_rpc": {
+          "import": "_rpc"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
I think the decoding here is in the wrong place. The filename should be encoded, while the payload is raw.