### PR TITLE
Updating node 10 and 12.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ commands:
     parameters:
       nv:
         type: string
-        default: "12.18.0"
+        default: '12.18.4'
       islatest:
         type: boolean
         default: false
@@ -41,15 +41,14 @@ jobs:
     executor: dockexec
     steps:
       - v_build:
-          nv: "10.17.0"
+          nv: '10.22.1'
 
   build_v12:
     executor: dockexec
     steps:
       - v_build:
-          nv: "12.18.0"
+          nv: '12.18.4'
           islatest: true
-
 
   build_placeholder:
     executor: dockexec

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
 FROM quay.io/redsift/sandbox:18.04-beta
 LABEL author.name="Karl Norling" \
   author.email="karl.norling@redsift.io" \
-  version="1.1.101" \
+  version="1.1.102" \
   organization="Red Sift"
 
 # nodev specifies node version
-ARG nodev=12.18.0
+ARG nodev=12.18.4
 LABEL io.redsift.sandbox.install="/usr/bin/redsift/install.js" io.redsift.sandbox.run="/usr/bin/redsift/run.js"
 
 ENV NVM_VERSION 0.35.2
 ENV NVM_DIR /usr/local/nvm
 ENV NODE_VERSION=${nodev}
-ENV NPM_VERSION=6.14.4
+ENV NPM_VERSION=6.14.6
 
 # Install a minimal git + python + build tools as npm and node-gyp often needs it for modules
 RUN export DEBIAN_FRONTEND=noninteractive && \

--- a/root/usr/bin/redsift/install_capnp
+++ b/root/usr/bin/redsift/install_capnp
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-nv="${NODE_VERSION:-12.18.0}"
+nv="${NODE_VERSION:-12.18.4}"
 
 echo "Installing node-capnp..."
 


### PR DESCRIPTION
Updates are now available for v10,x, v12.x and v14.x Node.js release lines for the following issues.

### HTTP Request Smuggling due to CR-to-Hyphen conversion (High) (CVE-2020-8201)

Affected Node.js versions converted carriage returns in HTTP request headers to a hyphen before parsing. This can lead to HTTP Request Smuggling as it is a non-standard interpretation of the header.

Impacts:
* All versions of the 14.x and 12.x releases lines

Thank you to Amit Klein who works at Safebreach for reporting this vulnerability.

### Denial of Service by resource exhaustion CWE-400 due to unfinished HTTP/1.1 requests (Critical) (CVE-2020-8251)

Node.js is vulnerable to HTTP denial of service (DOS) attacks based on delayed requests submission which can make the server unable to accept new connections. The fix a new http.Server option called requestTimeout
with a default value of 0 which means it is disabled by default. This should be set when Node.js is used as an edge server, for more details refer to the documentation.

Impacts:
* All versions of the 14.x release line

Thank you to Paolo Insogna and Matteo Collina who work at NearFom for reporting and fixing this vulnerability.

### fs.realpath.native on may cause buffer overflow (Medium) (CVE-2020-8252)

libuv's realpath implementation incorrectly determined the buffer size which can result in a buffer overflow if the resolved path is longer than 256 bytes.

Impacts:

* All versions of the 10.x release line
* All versions of the 12.x release line
* All versions of the 14.x release line before 14.9.0

## Downloads and release details

* [Node.js v10.22.1 (LTS)](https://nodejs.org/en/blog/release/v10.22.1/)
* [Node.js v12.18.4 (LTS)](https://nodejs.org/en/blog/release/v12.18.4/)
* [Node.js v14.11.0 (Current)](https://nodejs.org/en/blog/release/v14.11.0/)
